### PR TITLE
fix(rook-ceph): correct bluestore_slow_ops_warn_threshold option name

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
           osd_class_update_on_start: "false" # quote
           device_failure_prediction_mode: local # requires mgr module
         osd:
-          bluestore_slowops_warn_threshold: "50" # quote
+          bluestore_slow_ops_warn_threshold: "50" # quote
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       crashCollector:


### PR DESCRIPTION
The osd config key added in 492118c (`chore: fix stupid bluestore`) is misspelled: `bluestore_slowops_warn_threshold` → the real Ceph option is `bluestore_slow_ops_warn_threshold` ([Ceph health-checks docs](https://docs.ceph.com/en/latest/rados/operations/health-checks/)).

Ceph rejects unknown config keys, so every `rook-ceph-cluster` Helm upgrade since Jul 28 failed with `failed to set keys [bluestore_slowops_warn_threshold]` and timed out, leaving the HR Stalled — which blocks every app Kustomization that depends on `rook-ceph-cluster` (currently holding up the kopiur canary on qui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)