### PR TITLE
fix(kopiur): enable credentialProjection RBAC feature flag

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -10,6 +10,11 @@ spec:
     name: kopiur
   interval: 1h
   values:
+    # Grants the operator ClusterRole secrets create/patch so it can project
+    # the repository credentials into mover namespaces (credentialProjection)
+    features:
+      credentialProjection:
+        enabled: true
     monitoring:
       dashboards:
         enabled: true


### PR DESCRIPTION
The canary snapshot for `qui` stayed Pending: the operator gets HTTP 403 writing the projected credentials Secret into `default`. Our CRs opt into `credentialProjection`, but the chart's `features.credentialProjection.enabled` defaults to `false`, which withholds the cluster-wide `secrets` create/patch RBAC the projection needs (per the operator's own error hint).

One-line values fix. After merge the pending Snapshot `qui-manual-20260731001034` should unblock on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)