### PR TITLE
fix(n8n): define TIMEZONE substitution variable

### DIFF
--- a/kubernetes/apps/default/n8n/ks.yaml
+++ b/kubernetes/apps/default/n8n/ks.yaml
@@ -22,6 +22,7 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 5Gi
+      TIMEZONE: America/New_York
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   sourceRef:


### PR DESCRIPTION
n8n's HelmRelease has referenced ${TIMEZONE} since initial deploy, but no
Kustomization defines it. The flux-operator 0.53 upgrade made envsubst
strict, so n8n's ks has failed post-build ever since (last applied:
fc54c81), blocking today's kopiur cutover from pruning its
ReplicationSource.

Pair-programmed with Claude Code - https://claude.com/claude-code

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: chr1sd <satellitecactus@gmail.com>
