### PR TITLE
fix(stirling-pdf): define TIMEZONE substitution variable

### DIFF
--- a/kubernetes/apps/default/stirling-pdf/ks.yaml
+++ b/kubernetes/apps/default/stirling-pdf/ks.yaml
@@ -14,6 +14,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      TIMEZONE: America/New_York
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
Same failure class as n8n (#923): the HelmRelease references ${TIMEZONE},
undefined anywhere, fatal since flux-operator 0.53 made envsubst strict.

Pair-programmed with Claude Code - https://claude.com/claude-code

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: chr1sd <satellitecactus@gmail.com>
