### PR TITLE
chore(kopiur): read repository password from renamed 1Password item

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
@@ -15,4 +15,4 @@ spec:
         KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
   dataFrom:
     - extract:
-        key: volsync
+        key: kopiur


### PR DESCRIPTION
The 1Password item 'volsync' is being renamed to 'kopiur' (it holds the
kopia repository encryption password, which outlived the volsync era).
KOPIA_PASSWORD key inside the item is unchanged.

Pair-programmed with Claude Code - https://claude.com/claude-code

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: chr1sd <satellitecactus@gmail.com>
