### PR TITLE
fix(cloudnative-pg): superuser secret username must be the literal postgres

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -13,7 +13,9 @@ spec:
     template:
       type: kubernetes.io/basic-auth
       data:
-        username: "{{ .POSTGRES_SUPER_USER }}"
+        # CNPG requires the superuser secret's username to be exactly
+        # "postgres"; the old POSTGRES_SUPER_USER value was an app user
+        username: postgres
         password: "{{ .POSTGRES_SUPER_PASS }}"
   dataFrom:
     - extract:


### PR DESCRIPTION
The 1Password POSTGRES_SUPER_USER value is 'satellite-user-pg' (an app
user carried over from the broken March sops secret). CNPG only manages
the postgres role via superuserSecret, so template the username as a
constant and keep only the password from 1Password.

Pair-programmed with Claude Code - https://claude.com/claude-code

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: chr1sd <satellitecactus@gmail.com>
