### PR TITLE
feat(recyclarr): add anime quality profiles for sonarr

### DIFF
--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -32,9 +32,6 @@ sonarr:
         reset_unmatched_scores: &sonarr_reset_unmatched
           enabled: true
           except:
-            - "Language: Not Original or English"
-            - "Language: Prefer Original"
-            - "Language: German + Original"
             - "Sign Languages"
             - "FLUX Season Pack"
             - "Kitsune Season Pack"
@@ -159,6 +156,95 @@ sonarr:
               - WEBDL-480p
               - WEBRip-480p
               - DVD
+
+      # Anime profiles follow the TRaSH anime guide: Remux + Bluray are merged and
+      # HDTV is merged with WEB because anime release naming can't reliably tell
+      # them apart. score_set anime-sonarr applies TRaSH's anime scores to shared
+      # CFs (Remux Tiers 975/950, DSNP/NF/AMZN 5/4/3, AV1 reject).
+      # https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-anime/
+      - name: ANIME-REMUX-2160p
+        score_set: anime-sonarr
+        reset_unmatched_scores: &anime_reset_unmatched
+          enabled: true
+          except:
+            - "Anime Home Groups"
+            - "FLUX Season Pack"
+            - "Kitsune Season Pack"
+        upgrade:
+          allowed: true
+          until_quality: &anime-bluray-2160p Bluray-2160p
+          until_score: 10000
+        min_format_score: 0
+        qualities:
+          - name: *anime-bluray-2160p
+            qualities:
+              - Bluray-2160p Remux
+              - Bluray-2160p
+          - &anime-web-2160p
+            name: WEBDL-2160p
+            qualities:
+              - WEBDL-2160p
+              - WEBRip-2160p
+              - HDTV-2160p
+          - &anime-bluray-1080p
+            name: Bluray-1080p
+            qualities:
+              - Bluray-1080p Remux
+              - Bluray-1080p
+          - &anime-web-1080p
+            name: WEBDL-1080p
+            qualities:
+              - WEBDL-1080p
+              - WEBRip-1080p
+              - HDTV-1080p
+          - name: Bluray-720p
+          - &anime-web-720p
+            name: WEBDL-720p
+            qualities:
+              - WEBDL-720p
+              - WEBRip-720p
+              - HDTV-720p
+          - name: Bluray-576p
+          - name: Bluray-480p
+          - &anime-480p
+            name: 480p
+            qualities:
+              - WEBDL-480p
+              - WEBRip-480p
+              - DVD
+
+      - name: ANIME-REMUX-1080p
+        score_set: anime-sonarr
+        reset_unmatched_scores: *anime_reset_unmatched
+        upgrade:
+          allowed: true
+          until_quality: Bluray-1080p
+          until_score: 10000
+        min_format_score: 0
+        qualities:
+          - *anime-bluray-1080p
+          - *anime-web-1080p
+          - name: Bluray-720p
+          - *anime-web-720p
+          - name: Bluray-576p
+          - name: Bluray-480p
+          - *anime-480p
+
+      # WEB-only, per the TRaSH anime FAQ. Cutoff stays at 1080p; 2160p WEB is
+      # accepted if it is what exists but is not an upgrade target.
+      - name: ANIME-WEBDL
+        score_set: anime-sonarr
+        reset_unmatched_scores: *anime_reset_unmatched
+        upgrade:
+          allowed: true
+          until_quality: WEBDL-1080p
+          until_score: 10000
+        min_format_score: 0
+        qualities:
+          - *anime-web-2160p
+          - *anime-web-1080p
+          - *anime-web-720p
+          - *anime-480p
 
     # Custom Formats
     # This section creates and/or updates Custom Formats in your Sonarr instance,
@@ -310,6 +396,112 @@ sonarr:
           - b40dc2e630723745aab9f1b94f4aab74 # With BASL
           - 0aef382c4ed4c5eb5d40109dfd351b72 # With BSL
         assign_scores_to: *reject_scores
+
+      # Anime scoring (TRaSH anime guide). Explicit scores below are preferences;
+      # everything else takes the anime-sonarr score set via the profiles above.
+      - trash_ids:
+          # Anime release groups
+          - 949c16fe0a8147f50ba82cc2df9411c9 # Anime BD Tier 01
+          - ed7f1e315e000aef424a58517fa48727 # Anime BD Tier 02
+          - 096e406c92baa713da4a72d88030b815 # Anime BD Tier 03
+          - 30feba9da3030c5ed1e0f7d610bcadc4 # Anime BD Tier 04
+          - 545a76b14ddc349b8b185a6344e28b04 # Anime BD Tier 05
+          - 25d2afecab632b1582eaf03b63055f72 # Anime BD Tier 06
+          - 0329044e3d9137b08502a9f84a7e58db # Anime BD Tier 07
+          - c81bbfb47fed3d5a3ad027d077f889de # Anime BD Tier 08
+          - e0014372773c8f0e1bef8824f00c7dc4 # Anime Web Tier 01
+          - 19180499de5ef2b84b6ec59aae444696 # Anime Web Tier 02
+          - c27f2ae6a4e82373b0f1da094e2489ad # Anime Web Tier 03
+          - 4fd5528a3a8024e6b49f9c67053ea5f3 # Anime Web Tier 04
+          - 29c2a13d091144f63307e4a8ce963a39 # Anime Web Tier 05
+          - dc262f88d74c651b12e9d90b39f6c753 # Anime Web Tier 06
+          - 9965a052eb87b0d10313b1cea89eb451 # Remux Tier 01
+          - 8a1d0c3d7497e741736761a1da866a2e # Remux Tier 02
+
+          # Anime versions
+          - d2d7b8a9d39413da5f44054080e028a3 # v0
+          - 273bd326df95955e1b6c26527d1df89b # v1
+          - 228b8ee9aa0a609463efca874524a6b8 # v2
+          - 0e5833d3af2cc5fa96a0c29cd4477feb # v3
+          - 4fc15eeb8f2f9a749f918217d4234ad8 # v4
+
+          # Anime streaming services
+          - 3e0b26604165f463f3e8e192261e7284 # CR
+          - 44a8ee6403071dd7b8a3a8dd3fe8cb20 # VRV
+          - 1284d18e693de8efe0fe7d6b3e0b9170 # FUNi
+          - a370d974bc7b80374de1d9ba7519760b # ABEMA
+          - 89358767a60cc28783cdc3d0be9388a4 # DSNP
+          - d34870697c9db575f17700212167be23 # NF
+          - d660701077794679fd59e8bdf4ce3a29 # AMZN
+
+          # Misc
+          - 3bc5f395426614e155e585a2f056cdf1 # Season Pack
+        assign_scores_to:
+          - name: ANIME-REMUX-2160p
+          - name: ANIME-REMUX-1080p
+          - name: ANIME-WEBDL
+      # Synced for visibility, no preference (no guide score).
+      - trash_ids:
+          - 7dd31f3dee6d2ef8eeaa156e23c3857e # B-Global
+          - 4c67ff059210182b59cdd41697b8cb08 # Bilibili
+          - 570b03b3145a25011bf073274a407259 # HIDIVE
+          - b2550eb333d27b75833e25b8c2557b38 # 10bit
+        assign_scores_to:
+          - name: ANIME-REMUX-2160p
+            score: 0
+          - name: ANIME-REMUX-1080p
+            score: 0
+          - name: ANIME-WEBDL
+            score: 0
+      # Prefer dual audio and uncensored within the same release group tier.
+      - trash_ids:
+          - 418f50b10f1907201b6cfdf881f467b7 # Anime Dual Audio
+          - 026d5aadd1a6b4e550b134cb6c72b3ca # Uncensored
+        assign_scores_to:
+          - name: ANIME-REMUX-2160p
+            score: 10
+          - name: ANIME-REMUX-1080p
+            score: 10
+          - name: ANIME-WEBDL
+            score: 10
+      # Keep unwanted formats below the minimum score even when positive scores stack.
+      # x265 (no HDR/DV), Scene, Retags and No-RlsGroup are deliberately NOT here:
+      # anime encodes are routinely x265 10bit and fansub naming trips the others.
+      - trash_ids:
+          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
+          - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK
+          - 9c11cd3f07101cdba90a2d81cf0e56b4 # LQ
+          - e2315f990da2e2cbfc9fa5b7a6fcfe48 # LQ (Release Title)
+          - fbcb31d8dabd2a319072b84fc0b7249c # Extras
+          - 23297a736ca77c0fc8e70f8edd7ee56c # Upscaled
+          - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
+          - e3515e519f3b1360cbfc17651944354c # Anime LQ Groups
+          - b4a1b3d705159cdca36d71e57ca86871 # Anime Raws
+          - 9c14d194486c4014d422adc64092d794 # Dubs Only
+          - 44ccbcbc74506f208973e1463b11705f # With audio description
+          - c196536ea8122397c5854040d01f2aa7 # With ASL
+          - b40dc2e630723745aab9f1b94f4aab74 # With BASL
+          - 0aef382c4ed4c5eb5d40109dfd351b72 # With BSL
+        assign_scores_to:
+          - name: ANIME-REMUX-2160p
+            score: -50000
+          - name: ANIME-REMUX-1080p
+            score: -50000
+          - name: ANIME-WEBDL
+            score: -50000
+      # HDR only matters at 2160p.
+      - trash_ids:
+          - 505d871304820ba7106b693be6fe4a9e # HDR
+          - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
+          - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+          - ef4963043b0987f8485bc9106f16db38 # DV Disk
+        assign_scores_to:
+          - name: ANIME-REMUX-2160p
+      - trash_ids:
+          - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
+        assign_scores_to:
+          - name: ANIME-REMUX-2160p
+            score: -600
 
 radarr:
   movies:


### PR DESCRIPTION
## Summary

Adds three Sonarr quality profiles for anime, modeled on the existing BLURAY/WEBDL profiles and the TRaSH anime guide:

| Profile | Cutoff | Qualities |
|---|---|---|
| `ANIME-REMUX-2160p` | Bluray-2160p group | Bluray-2160p Remux + Bluray-2160p merged, then WEB-2160p, 1080p ladder, 720p, SD |
| `ANIME-REMUX-1080p` | Bluray-1080p group | Bluray-1080p Remux + Bluray-1080p merged, WEB-1080p (incl. HDTV), 720p, SD |
| `ANIME-WEBDL` | WEBDL-1080p group | WEB only (2160p accepted, not an upgrade target) |

All three use `score_set: anime-sonarr` so shared CFs take TRaSH's anime scores (Remux Tier 01/02 = 975/950, DSNP/NF/AMZN = 5/4/3, AV1 rejected).

### Scoring
- **Positive:** Anime BD Tier 01–08, Anime Web Tier 01–06, Remux Tier 01/02, v0–v4, CR/VRV/FUNi/ABEMA + DSNP/NF/AMZN, Season Pack. Anime Dual Audio +10, Uncensored +10 (prefer within tier). B-Global/Bilibili/HIDIVE/10bit synced at 0.
- **Rejected (-50000):** AV1, BR-DISK, LQ, LQ (Release Title), Extras, Upscaled, Bad Dual Groups, Anime LQ Groups, Anime Raws, Dubs Only, accessibility CFs.
- **Deliberately not rejected for anime:** x265 (no HDR/DV), Scene, Retags, No-RlsGroup.
- **Not included:** audio CFs (FLAC 2250 would outrank Anime BD Tier 01 at 1400). HDR/DV boosts on the 2160p profile only.
- `reset_unmatched_scores.except` keeps the hand-made `Anime Home Groups`, `FLUX Season Pack`, `Kitsune Season Pack` scores. Three dead `Language: ...` exceptions removed (CFs no longer exist in Sonarr).

### Verification
- YAML parses; no duplicate (profile, trash_id) assignments.
- Throwaway in-cluster Job ran `recyclarr sync sonarr --preview --log debug` against this config: 130 CFs processed (33 new anime), new merged quality groups planned, existing profiles unchanged, no warnings or errors. Job and ConfigMap deleted afterwards.

### Post-merge (manual, outside Git)
1. After the first sync creates the profiles, set `Anime Home Groups` to **+500** in each anime profile (SubsPlease at Web Tier 05 = 200 → 700, above Web Tier 01 at 600).
2. Move series off the hand-made `Remux-1080p - Anime` / `[Anime] Remux-1080p` profiles and delete them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J1RLE72wTiqhjBTmJvKSg
